### PR TITLE
chore: Revert "chore: Remove workflow not relevant for public repo"

### DIFF
--- a/.github/workflows/approve-and-merge-dependabot-pr.yaml
+++ b/.github/workflows/approve-and-merge-dependabot-pr.yaml
@@ -1,0 +1,13 @@
+on:
+  pull_request_target:
+    types: [assigned, opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  main:
+    name: Approve and merge Dependabot PR
+    uses: coopnorge/github-workflow-approve-and-merge-dependabot-pr/.github/workflows/approve-and-merge-dependabot-pr.yaml@main
+    secrets:
+      reviewbot-github-token: ${{ secrets.REVIEWBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 62a187618613e329a2c5819e889a79a2a48853f3.

It was removed by mistake. The dependabot PR auto-merge can still be useful here. It was not working before because the secret was not configured for public repos.